### PR TITLE
Fix: Add Boolean support to Query equalTo

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -62,15 +62,21 @@ exports.priAndKeyComparator = function priAndKeyComparator(testPri, testKey, val
 };
 
 exports.priorityComparator = function priorityComparator(a, b) {
+  // https://firebase.google.com/docs/database/web/lists-of-data#data-order
   if (a !== b) {
     if (a === null || b === null) {
       return a === null ? -1 : 1;
     }
-    if (typeof a !== typeof b) {
-      return typeof a === 'number' ? -1 : 1;
-    } else {
-      return a > b ? 1 : -1;
+    if(typeof a === 'boolean' && typeof b === 'boolean') {
+      return !a ? -1 : 1;
     }
+    if (typeof a !== typeof b) {
+      if(typeof a === 'boolean' || typeof b === 'boolean') {
+        return typeof a === 'boolean' ? -1 : 1;
+      }
+      return typeof a === 'number' ? -1 : 1;
+    }
+    return a > b ? 1 : -1;
   }
   return 0;
 };

--- a/test/unit/data.json
+++ b/test/unit/data.json
@@ -77,6 +77,12 @@
     "char_c": {
       ".priority": "c",
       "aLetter": "c"
+    },
+    "zbool_true": {
+      "aBoolean": true
+    },
+    "zbool_false": {
+      "aBoolean": false
     }
   },
   "collections": {

--- a/test/unit/data.json
+++ b/test/unit/data.json
@@ -78,10 +78,12 @@
       ".priority": "c",
       "aLetter": "c"
     },
-    "zbool_true": {
+    "bool_true": {
+      ".priority": true,
       "aBoolean": true
     },
-    "zbool_false": {
+    "bool_false": {
+      ".priority": false,
       "aBoolean": false
     }
   },

--- a/test/unit/query.js
+++ b/test/unit/query.js
@@ -146,6 +146,16 @@ describe('MockQuery', function () {
         expect(spy.called).to.equal(true);
       });
 
+      it('should work with boolean equalTo', function() {
+        var spy = sinon.spy(function(snap) {
+          expect(_.keys(snap.val())).eql(['zbool_true']);
+        });
+
+        ref.limitToLast(2).equalTo(true).on('value', spy);
+        ref.flush();
+        expect(spy).callCount(1);
+      });
+
       it('should return null if not equalTo', function() {
         var spy = sinon.spy(function(snap) {
           expect(snap.val()).equals(null);
@@ -344,9 +354,5 @@ describe('MockQuery', function () {
     it('should start at the key given');
 
     it('should start at the key+priority given');
-  });
-
-  describe('equalTo', function() {
-    it('should start and stop at the key given');
   });
 });

--- a/test/unit/query.js
+++ b/test/unit/query.js
@@ -148,10 +148,10 @@ describe('MockQuery', function () {
 
       it('should work with boolean equalTo', function() {
         var spy = sinon.spy(function(snap) {
-          expect(_.keys(snap.val())).eql(['zbool_true']);
+          expect(_.keys(snap.val())).eql(['bool_true']);
         });
 
-        ref.limitToLast(2).equalTo(true).on('value', spy);
+        ref.equalTo(true).on('value', spy);
         ref.flush();
         expect(spy).callCount(1);
       });

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -7,6 +7,7 @@ var removeEmptyRtdbProperties = require('../../src/utils').removeEmptyRtdbProper
 var removeEmptyFirestoreProperties = require('../../src/utils').removeEmptyFirestoreProperties;
 var updateToRtdbObject = require('../../src/utils').updateToRtdbObject;
 var updateToFirestoreObject = require('../../src/utils').updateToFirestoreObject;
+var priorityComparator = require('../../src/utils').priorityComparator;
 
 describe('utils', function () {
   describe('removeEmptyRtdbProperties', function () {
@@ -162,6 +163,45 @@ describe('utils', function () {
           }
         }
       });
+    });
+  });
+
+  describe('priorityComparator', function() {
+    // https://firebase.google.com/docs/database/web/lists-of-data#data-order
+    it('should give no priority to equal items', function() {
+      expect(priorityComparator('a', 'a')).to.eql(0);
+    });
+    it('should order null items first', function() {
+      expect(priorityComparator(null, 0)).to.eql(-1);
+      expect(priorityComparator(0, null)).to.eql(1);
+    });
+    it('should order false before true', function() {
+      expect(priorityComparator(false, true)).to.eql(-1);
+      expect(priorityComparator(true, false)).to.eql(1);
+    });
+    it('should order booleans before numbers', function() {
+      expect(priorityComparator(false, 0)).to.eql(-1);
+      expect(priorityComparator(true, 1)).to.eql(-1);
+      expect(priorityComparator(0, false)).to.eql(1);
+      expect(priorityComparator(1, true)).to.eql(1);
+    });
+    it('should order numbers before strings', function() {
+      expect(priorityComparator(5, 'foo')).to.eql(-1);
+      expect(priorityComparator(3, '3')).to.eql(-1);
+      expect(priorityComparator('foo', 0)).to.eql(1);
+      expect(priorityComparator('10', 10)).to.eql(1);
+    });
+    it('should order numbers in ascending order', function() {
+      expect(priorityComparator(4,5)).to.eql(-1);
+      expect(priorityComparator(5,4)).to.eql(1);
+      expect(priorityComparator(1,10)).to.eql(-1);
+      expect(priorityComparator(10,1)).to.eql(1);
+    });
+    it('should order strings lexicographically', function() {
+      expect(priorityComparator('bar', 'foo')).to.eql(-1);
+      expect(priorityComparator('foo', 'bar')).to.eql(1);
+      expect(priorityComparator('ant', 'art')).to.eql(-1);
+      expect(priorityComparator('art', 'ant')).to.eql(1);
     });
   });
 });


### PR DESCRIPTION
Continued PR from [here](https://github.com/soumak77/firebase-mock/pull/167).

Test is failing, investigation needed.

Preliminary thoughts as per @dmurvihill 
> I've been looking into this; I think the priorityComparator method (utils.js:64) is incomplete. It seems to be interested only in priorities of type null, string, and number, ignoring boolean and object values in spite of the Firebase docs.

> There may (not sure) also be a problem with Slice.prototype._inRange (slice.js:85) which might be doing an exclusive rather than an inclusive range.