### PR TITLE
Implement onIdTokenChanged and update onAuthStateChanged 

### DIFF
--- a/API.md
+++ b/API.md
@@ -175,8 +175,9 @@ Authentication methods for simulating changes to the auth state of a Firebase re
 Changes the active authentication credentials to the `authData` object.
 Before changing the authentication state, `changeAuthState` checks the
 `user` object against the current authentication data.
-`onAuthStateChanged` listeners will only be triggered if the data is not
-deeply equal.
+`onIdTokenChanged` listeners will be triggered if the data is not
+deeply equal. `onAuthStateChanged` listeners will be triggered if the
+data is deeply equal but with different ID token validity.
 
 `user` should be a `MockUser` object or an object with the same fields
 as `MockUser`. To simulate no user being authenticated, pass `null` for
@@ -225,9 +226,13 @@ Finds a user previously created with [`createUser`](https://www.firebase.com/doc
 ##### `updateUser(user)` -> `Promise<MockUser>`
 
 Replace the existing user with a new one, by matching uid. Throws an
-error if no user exists whose uid matches the given user's uid. Resolves
-with the updated user when complete. This operation is queued until the
-next flush.
+error if no user exists whose uid matches the given user's uid.
+Appropriate `onAuthStateChanged` and `onIdTokenChanged` listeners will
+be triggered if the new user has the same `uid` as the current
+authenticated user.
+
+Resolves with the updated user when complete. This operation is queued
+until the next flush.
 
 ## Server Timestamps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Changelog
-- mock `auth.Auth.onIdTokenChanged()` method, matching the previous
+- Mock `auth.Auth.onIdTokenChanged()` method, matching the previous
   behavior of `onAuthStateChanged()` (see below)
 
 ### Changed
-- (Breaking) Consistent with Firebase SDK
-  [version 4.0.0](https://firebase.google.com/support/release-notes/js#version_500_-_may_8_2018) and later,
+- (Breaking) Consistent with Firebase SDK [version 4.0.0](https://firebase.google.com/support/release-notes/js#version_500_-_may_8_2018) and later,
   and later, `onAuthStateChanged` no longer issues an event when a new
   ID token is issued for the same user. The `onIdTokenChanged` method is
   now mocked, keeping the previous behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Changelog
+- mock `auth.Auth.onIdTokenChanged()` method, matching the previous
+  behavior of `onAuthStateChanged()` (see below)
 
 ### Changed
+- (Breaking) Consistent with Firebase SDK
+  [version 4.0.0](https://firebase.google.com/support/release-notes/js#version_500_-_may_8_2018) and later,
+  and later, `onAuthStateChanged` no longer issues an event when a new
+  ID token is issued for the same user. The `onIdTokenChanged` method is
+  now mocked, keeping the previous behavior.
 - `MockStorageFile.download()` now allows omitting the destination arg;
   in that case, it simply resolves the `Promise` with the file contents
   and does not write it anywhere else.

--- a/src/firebase-auth.js
+++ b/src/firebase-auth.js
@@ -180,7 +180,7 @@ Object.keys(signinMethods)
     FirebaseAuth.prototype[method] = function () {
       var self = this;
       var user = getUser.apply(this, arguments);
-      var promise = new Promise(function(resolve, reject) {
+      return new Promise(function(resolve, reject) {
         self._authEvent(method, function(err) {
           if (err) reject(err);
           self.currentUser = user;
@@ -276,7 +276,7 @@ FirebaseAuth.prototype.unauth = function () {
 
 FirebaseAuth.prototype.signOut = function () {
   var self = this, updateuser = this.currentUser !== null;
-  var promise = new Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     self._authEvent('signOut', function(err) {
       if (err) reject(err);
       self.currentUser = null;
@@ -287,7 +287,6 @@ FirebaseAuth.prototype.signOut = function () {
       }
     }, true);
   });
-  return promise;
 };
 
 FirebaseAuth.prototype.createUserWithEmailAndPassword = function (email, password) {
@@ -569,7 +568,7 @@ FirebaseAuth.prototype._nextUid = function () {
 FirebaseAuth.prototype._validateNewUid = function (uid) {
   if (uid) {
     var user = _.find(this._auth.users, function(user) {
-      return user.uid == uid;
+      return user.uid === uid;
     });
     if (user) {
       var err = new Error('The provided uid is already in use by an existing user. Each user must have a unique uid.');
@@ -583,7 +582,7 @@ FirebaseAuth.prototype._validateNewUid = function (uid) {
 FirebaseAuth.prototype._validateExistingUid = function (uid) {
   if (uid) {
     var user = _.find(this._auth.users, function(user) {
-      return user.uid == uid;
+      return user.uid === uid;
     });
     if (!user) {
       var err = new Error('There is no existing user record corresponding to the provided identifier.');

--- a/src/user.js
+++ b/src/user.js
@@ -114,13 +114,8 @@ MockFirebaseUser.prototype.updateProfile = function (profile) {
 };
 
 MockFirebaseUser.prototype.getIdToken = function (forceRefresh) {
-  var self = this;
-  return new Promise(function(resolve) {
-    if (forceRefresh) {
-        self._refreshIdToken();
-    }
-    resolve(self._idtoken);
-  });
+  return (forceRefresh ? this._refreshIdToken() : Promise.resolve())
+    .then(() => this._idtoken);
 };
 
 MockFirebaseUser.prototype.toJSON = function() {

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -931,6 +931,18 @@ describe('Auth', function () {
         .then(updatedUser => expect(updatedUser).to.deep.equal(newUser));
     });
 
+    it('preserves deep equality of users', () => {
+      ref.createUser(new User(ref, {
+        uid: 'kato',
+        email: 'test@example.com',
+      }));
+      return ref.getUser('kato').then(oldUser => {
+        ref.updateUser(oldUser)
+          .then(ref.getUser('kato'))
+          .then(newUser => expect(expect(oldUser).to.deep.equal(newUser)));
+      });
+    });
+
     it('should select by uid', () => {
       const uid = 456;
       const email = 'newEmail@example.com';

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -316,8 +316,12 @@ describe('Auth', function () {
   });
 
   describe('#onAuthStateChanged', function () {
-    it('is triggered when changeAuthState modifies data', function () {
+
+    beforeEach(() => {
       ref.onAuthStateChanged(spy);
+    });
+
+    it('is triggered when changeAuthState modifies data', function () {
       ref.changeAuthState({
         uid: 'kato'
       });
@@ -328,7 +332,6 @@ describe('Auth', function () {
     });
 
     it('is not be triggered if auth state does not change', function () {
-      ref.onAuthStateChanged(spy);
       ref.changeAuthState({
         uid: 'kato'
       });
@@ -342,7 +345,6 @@ describe('Auth', function () {
     });
 
     it('synchronously triggers the callback with the current auth data', function () {
-      ref.onAuthStateChanged(spy);
       expect(spy).to.have.been.calledWith(null);
     });
   });

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -1006,7 +1006,7 @@ describe('Auth', function () {
       return ref.createUser({
         email: 'kato@kato.com',
         password: 'kato'
-      }).then(function(user) {
+      }).then(function() {
         var err = new Error('custom error');
         ref.failNext('setCustomUserClaims', err);
         return expect(ref.setCustomUserClaims('uid', {

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -23,7 +23,7 @@ describe('Auth', function () {
   describe('#changeAuthState', function () {
 
     it('sets the auth data', function () {
-      var user = {};
+      var user = new User(ref, {});
       ref.changeAuthState(user);
       ref.flush();
       expect(ref.getAuth()).to.equal(user);
@@ -266,18 +266,18 @@ describe('Auth', function () {
       var context = {};
       ref.onAuth(spy);
       ref.onAuth(spy, context);
-      ref.changeAuthState({
+      ref.changeAuthState(new User(ref, {
         uid: 'kato1'
-      });
+      }));
       ref.flush();
       expect(spy.callCount).to.equal(4);
       spy.reset();
       // will not match any context
       ref.offAuth(spy, {});
       ref.offAuth(spy, context);
-      ref.changeAuthState({
+      ref.changeAuthState(new User(ref, {
         uid: 'kato2'
-      });
+      }));
       ref.flush();
       expect(spy.callCount).to.equal(1);
     });
@@ -331,7 +331,7 @@ describe('Auth', function () {
       });
     });
 
-    it('is not be triggered if auth state does not change', function () {
+    it('is not triggered if auth state does not change', function () {
       ref.changeAuthState({
         uid: 'kato'
       });

--- a/test/unit/user.js
+++ b/test/unit/user.js
@@ -97,6 +97,16 @@ describe('User', function() {
       u1._auth.autoFlush(false);
       expect(u2._auth.flushDelay).to.equal(u1._auth.flushDelay);
    });
+
+    it('preserves deep equality', () => {
+      const user = new User(auth, {
+        customClaims: {
+          'a': 1,
+        },
+      });
+      clock.tick(1000);
+      expect(user.clone()).to.deep.equal(user);
+    });
   });
 
   describe('#delete', function() {

--- a/test/unit/user.js
+++ b/test/unit/user.js
@@ -217,7 +217,7 @@ describe('User', function() {
 
   describe('#getIdToken', function() {
     it('should get token', function() {
-      var user = new User(auth, {});
+      const user = new User(auth, {});
       return expect(user.getIdToken()).to.eventually.not.be.empty;
     });
 

--- a/test/unit/user.js
+++ b/test/unit/user.js
@@ -73,6 +73,12 @@ describe('User', function() {
         });
       }).to.throw(User.msg_tokenAuthedInTheFuture);
     });
+
+    it('should keep reference to passed-in auth', () => {
+      const user = new User(auth, {});
+      auth.autoFlush(false);
+      expect(user._auth.flushDelay).to.equal(false);
+    });
   });
 
   describe('#clone', function() {
@@ -84,6 +90,13 @@ describe('User', function() {
       u2.customClaims.claim1 = 'value2';
       expect(u1.customClaims).to.deep.equal(ogClaims);
     });
+
+    it('preserves reference to auth', () => {
+      const u1 = new User(auth, {});
+      const u2 = u1.clone();
+      u1._auth.autoFlush(false);
+      expect(u2._auth.flushDelay).to.equal(u1._auth.flushDelay);
+   });
   });
 
   describe('#delete', function() {


### PR DESCRIPTION
Firebase SDK [Version 4.0.0](https://firebase.google.com/support/release-notes/js#version_500_-_may_8_2018)
changed the behavior of `onAuthStateChanged` and added a new event handler
called `onIdTokenChanged`. This patch mocks that change.

onIdTokenChanged now implements the former behavior of onAuthStateChanged.
onAuthStateChanged now signals only when the actual user changes, not when
a new ID token is set for the same user.

Resolves #2.