### PR TITLE
Adds support for listCollections on collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior of `onAuthStateChanged()` (see below)
 - Support for Firebase Messaging (Admin API)
 - Support for [FieldValue.increment](https://firebase.google.com/docs/reference/js/firebase.firestore.FieldValue#increment)
+- Support for `listCollections` in [DocumentReferences](https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#listCollections)
 
 ### Changed
 - (Breaking) Consistent with Firebase SDK [version 4.0.0](https://firebase.google.com/support/release-notes/js#version_500_-_may_8_2018) and later,
@@ -23,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `onAuthStateChanged` now correctly calls its callback immediately with
-  the current auth state.  
+  the current auth state.
 - `MockStorage.bucket()` and `MockStorageBucket.file()` now return the
   existing artifact if one exists, rather than overwriting it with a new
   one.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8791,6 +8791,11 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
       "integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
     },
+    "lodash.clonewith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonewith/-/lodash.clonewith-4.5.0.tgz",
+      "integrity": "sha1-0UwSAz2r0XKJ97mrUiBlvfAf9GA="
+    },
     "lodash.compact": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
@@ -8896,6 +8901,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",

--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -267,6 +267,7 @@ MockFirestoreDocument.prototype.getCollections = function () {
     });
   });
 };
+MockFirestoreDocument.prototype.listCollections = MockFirestoreDocument.prototype.getCollections;
 
 MockFirestoreDocument.prototype._hasChild = function (key) {
   return _.isObject(this.data) && _.has(this.data, key);

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -624,6 +624,73 @@ describe('MockFirestoreDocument', function () {
     });
   });
 
+  describe('#listCollections', function () {
+    beforeEach(function () {
+      db.doc('doc/subcol/subcol-doc').set({ foo: 'bar' });
+      db.doc('doc/subcol2/subcol-doc').set({ foo: 'bar' });
+      db.doc('doc/subcol/subcol-doc/deep-col/deep-doc').set({ foo: 'bar' });
+      db.doc('doc/subcol/subcol-doc/deep-col2/deep-doc').set({ foo: 'bar' });
+      db.flush();
+    });
+    afterEach(function () {
+      db.doc('doc/subcol/subcol-doc').delete();
+      db.doc('doc/subcol2/subcol-doc').delete();
+      db.doc('doc/subcol/subcol-doc/deep-col/deep-doc').delete();
+      db.doc('doc/subcol/subcol-doc/deep-col2/deep-doc').delete();
+      db.flush();
+    });
+
+    context('when present', function () {
+      it('returns collections of document', function (done) {
+        db.doc('doc').listCollections().then(function (colRefs) {
+          expect(colRefs).to.be.an('array');
+          expect(colRefs).to.have.length(2);
+          expect(colRefs[0].path).to.equal('doc/subcol');
+          expect(colRefs[1].path).to.equal('doc/subcol2');
+          done();
+        });
+        db.flush();
+      });
+
+      it('returns deeply nested collections of document', function (done) {
+        db.doc('doc/subcol/subcol-doc').listCollections().then(function (colRefs) {
+          expect(colRefs).to.be.an('array');
+          expect(colRefs).to.have.length(2);
+          expect(colRefs[0].path).to.equal('doc/subcol/subcol-doc/deep-col');
+          expect(colRefs[1].path).to.equal('doc/subcol/subcol-doc/deep-col2');
+          done();
+        });
+        db.flush();
+      });
+    });
+
+    context('when not present', function () {
+      it('returns empty list of collections', function (done) {
+        db.doc('not-existing').listCollections().then(function (colRefs) {
+          expect(colRefs).to.be.an('array');
+          expect(colRefs).to.have.length(0);
+          done();
+        });
+        db.flush();
+      });
+
+      it('skips collections that has no documents', function (done) {
+        db.doc('doc/subcol/subcol-doc').delete();
+        db.doc('doc/subcol2/subcol-doc').delete();
+        db.doc('doc/subcol/subcol-doc/deep-col/deep-doc').delete();
+        db.doc('doc/subcol/subcol-doc/deep-col2/deep-doc').delete();
+        db.flush();
+
+        db.doc('doc').listCollections().then(function (colRefs) {
+          expect(colRefs).to.be.an('array');
+          expect(colRefs).to.have.length(0);
+          done();
+        });
+        db.flush();
+      });
+    });
+  });
+
   describe('#onSnapshot', function () {
     it('calls observer with initial state', function (done) {
       doc.onSnapshot(function(snap) {


### PR DESCRIPTION
On document references `getCollections` has been renamed to `listCollections` on later versions of Firestore.
This PR makes it compatible with the old as well as to the new versions.

I've copied and pasted the specs from `getCollections` and renamed them to `listCollections`. They are passing as well.

Here is the specs log:

https://gist.github.com/heygambo/5151096e79d978a1fe088553ff36b57b