### PR TITLE
added support for snapshot#docChanges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8791,6 +8791,11 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
       "integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
     },
+    "lodash.clonewith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonewith/-/lodash.clonewith-4.5.0.tgz",
+      "integrity": "sha1-0UwSAz2r0XKJ97mrUiBlvfAf9GA="
+    },
     "lodash.compact": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
@@ -8896,6 +8901,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",

--- a/src/firestore-query-snapshot.js
+++ b/src/firestore-query-snapshot.js
@@ -3,7 +3,9 @@
 var _ = require('./lodash');
 var DocumentSnapshot = require('./firestore-document-snapshot');
 
-function MockFirestoreQuerySnapshot (ref, data) {
+function MockFirestoreQuerySnapshot (ref, data, priorData) {
+  var self = this;
+
   this._ref = ref;
   this.data = _.cloneDeep(data) || {};
   if (_.isObject(this.data) && _.isEmpty(this.data)) {
@@ -12,17 +14,46 @@ function MockFirestoreQuerySnapshot (ref, data) {
   this.size = _.size(this.data);
   this.empty = this.size === 0;
 
-  var self = this;
   this.docs = _.map(this.data, function (value, key) {
     return new DocumentSnapshot(key, self._ref.doc(key), value);
   });
+
+  var prior = priorData || {};
+  this._changes = _.reduce(
+    this.docs,
+    function(changes, doc) {      
+      if (!prior[doc.id]) changes.push({ type: "added", doc });
+      if (prior[doc.id] && !_.isEqual(doc.data(), prior[doc.id]))
+        changes.push({ type: "modified", doc });
+
+      return changes;
+    },
+    []
+  );
+
+  _.forEach(prior, function (value, key) {
+    if (!data[key]) self._changes.push({ 
+      type: 'removed', 
+      doc: new DocumentSnapshot(key, self._ref.doc(key), value) 
+    });
+  })
 }
 
-MockFirestoreQuerySnapshot.prototype.forEach = function (callback, context) {
-  var self = this;
-  _.forEach(this.docs, function (doc) {
+MockFirestoreQuerySnapshot.prototype.forEach = function(callback, context) {
+  _.forEach(this.docs, function(doc) {
     callback.call(context, doc);
   });
+};
+
+MockFirestoreQuerySnapshot.prototype.docChanges = function() {
+  var self = this;
+  return {
+    forEach: function(callback, context) {
+      _.forEach(self._changes, function(change) {
+        callback.call(context, change);
+      });
+    }
+  };
 };
 
 module.exports = MockFirestoreQuerySnapshot;

--- a/src/firestore-query.js
+++ b/src/firestore-query.js
@@ -208,14 +208,14 @@ MockFirestoreQuery.prototype.onSnapshot = function (optionsOrObserverOrOnNext, o
   var context = {
     data: self._results(),
   };
-  var onSnapshot = function (forceTrigger) {
+  var onSnapshot = function (initialCall) {
     // compare the current state to the one from when this function was created
     // and send the data to the callback if different.
     if (err === null) {
-      if (forceTrigger) {
+      if (initialCall) {
         const results = self._results();
         if (_.size(self.data) !== 0) {
-          onNext(new QuerySnapshot(self.parent === null ? self : self.parent.collection(self.id), results));
+          onNext(new QuerySnapshot(self.parent === null ? self : self.parent.collection(self.id), results, {}));
         } else {
           onNext(new QuerySnapshot(self.parent === null ? self : self.parent.collection(self.id)));
         }
@@ -223,7 +223,7 @@ MockFirestoreQuery.prototype.onSnapshot = function (optionsOrObserverOrOnNext, o
         self.get().then(function (querySnapshot) {
           var results = self._results();
           if (!_.isEqual(results, context.data) || includeMetadataChanges) {
-            onNext(new QuerySnapshot(self.parent === null ? self : self.parent.collection(self.id), results));
+            onNext(new QuerySnapshot(self.parent === null ? self : self.parent.collection(self.id), results, context.data));
             context.data = results;
           }
         });


### PR DESCRIPTION
This implements the snapshot `docChanges` interface (https://firebase.google.com/docs/firestore/query-data/listen#view_changes_between_snapshots)

Includes tests.